### PR TITLE
Address jScript check digit generator error

### DIFF
--- a/ULI_CheckDigitCalc.jScript
+++ b/ULI_CheckDigitCalc.jScript
@@ -32,7 +32,7 @@ font-size: 14px;
 <p id="uliCheckDigits"></p>
 
 <script>
-//CFPB supplied sample LEI + Loan Id in Reg. C Appendix C describing method of calculation: "10Bx939c5543TqA1144M999143X" which should result in "38" as check digits appended at end to be "10Bx939c5543TqA1144M999143X38".
+//CFPB supplied sample LEI + Loan Id in Reg. C Appendix C describing method of calculation: "10Bx939c5543TqA1144M999143X" which should result in "38" as check digits appended at end to be "10Bx939c5543TqA1144M999143X38" and 549300410TULSMMGDX9251506124 should have check digit of "58".
 
 function UliReplaceAlpha(strULIToCheck) {
 var toRemove = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
@@ -74,13 +74,13 @@ try {
 	strNumToCheck = String(longMod97) + strNumToCheck;
       }    
     
-    document.getElementById("longMod97").innerHTML = "The mod 97 result of the tested value is: " + longMod97;
+    document.getElementById("longMod97").innerHTML = "The mod 97 result of the tested value is: " + strNumToCheck; //longMod97;
 
 }
 catch(err) {
 	document.getElementById("longMod97").innerHTML = "Error: " + err;
 }
-return longMod97;
+return strNumToCheck; //longMod97;
 }
 
 

--- a/ULI_CheckDigitCalc.jScript
+++ b/ULI_CheckDigitCalc.jScript
@@ -3,7 +3,7 @@
 <head>
 <style>
 p {
-style=ìfont-family: play, sans-serif;color:#003366;line-heigh:1.25em;test-align:justify;î;
+style=‚Äúfont-family: play, sans-serif;color:#003366;line-heigh:1.25em;test-align:justify;‚Äù;
 font-size: 14px;
 }
 </style>
@@ -74,13 +74,13 @@ try {
 	strNumToCheck = String(longMod97) + strNumToCheck;
       }    
     
-    document.getElementById("longMod97").innerHTML = "The mod 97 result of the tested value is: " + strNumToCheck; //longMod97;
+    document.getElementById("longMod97").innerHTML = "The mod 97 result of the tested value is: " + strNumToCheck;
 
 }
 catch(err) {
 	document.getElementById("longMod97").innerHTML = "Error: " + err;
 }
-return strNumToCheck; //longMod97;
+return strNumToCheck;
 }
 
 


### PR DESCRIPTION
When the second to last pass in the Mod97 loop resulted in a remainder of one digit and the final pass had only one digit left to append the last digit was not appended and the prior Mod97 result was returned instead of the appended result. A single digit in the second to last pass could occur 10 out of 97 times. The loop uses 7 digits which means there was a one in 7 chance of the final pass through the loop having one remaining digit.
 
The error was caused by returning the mod97 variable prior to appending that last digit, which was always zero. Because the final digit would always be zero, the proper check digits would always end in 8. In the example included in the code comments, the bad code was returning a 4 instead of a 40 and that resulted in erroneously reporting 94 instead of 58 for the check digits. 

The Validator tool called a different function so it was properly identifying that the generated value was invalid if the output from the generator was tested.